### PR TITLE
add deep views

### DIFF
--- a/verus/lcf/src/string_hash_map.rs
+++ b/verus/lcf/src/string_hash_map.rs
@@ -31,6 +31,19 @@ impl<Value> View for StringHashMap<Value> {
     closed spec fn view(&self) -> Self::V;
 }
 
+impl<Value> DeepView for StringHashMap<Value> 
+    where Value: DeepView
+{
+    type V = Map<Seq<char>, <Value as DeepView>::V>;
+
+    open spec fn deep_view(&self) -> Self::V {
+        self
+            .view()
+            .map_values(|v: Value| v.deep_view())
+    }
+}
+
+
 impl<Value:PartialEq> PartialEq for StringHashMap<Value> {
     fn eq(&self, other :&Self) -> bool{
         self.m == other.m


### PR DESCRIPTION
Add spec versions of data types and corresponding `impl DeepView`s. Note that the `impl DeepView` for `Proof` is currently uninterpreted, due to https://github.com/verus-lang/verus/issues/1222. This will need to be fixed based on that issue.